### PR TITLE
Increase MAX_UDS_PATH from 32 to 64

### DIFF
--- a/get_transient_token.c
+++ b/get_transient_token.c
@@ -82,7 +82,7 @@ int main()
     int rc;
 
     /* Create unix domain socket */
-    char udspath[MAX_UDS_PATH];
+    char udspath[MAX_UDS_PATH + 1];
     snprintf(udspath,
              sizeof(udspath),
              UDS_PATH,

--- a/transient_token.h
+++ b/transient_token.h
@@ -25,7 +25,7 @@
 
 #define CHALLENGE_SIZE_QUADS 4
 #define TIMEOUT_SECS 60
-#define MAX_UDS_PATH 32
+#define MAX_UDS_PATH 64
 #define UDS_PATH "/tmp/transient-token-%d-%d"
 
 #ifdef PAM_STATIC             /* for the case that this module is static */


### PR DESCRIPTION
We defined `MAX_UDS_PATH` as 32, but that is too short for almost any current Linux system. The static part of the path, `/tmp/transient-token--`, already eats up 23 bytes (including the terminating 0). Current Linux systems usually default to using pids up to 4194304, meaning the pid part will take up to 7 bytes, and user-ids of up to 999999 (6 bytes) are not that uncommon either, meaning we'll end up with a path that is 23+7+6 = 36 bytes long. While we're at it, lets also make the usage of the define consistent: pam_transient_token.c added 1 byte for the terminating 0, get_transient_token.c did not - we're changing the latter to also add 1.